### PR TITLE
SecureDrop: fix config.json wrongly set to prod

### DIFF
--- a/tests/securedrop/install_workstation.pm
+++ b/tests/securedrop/install_workstation.pm
@@ -48,6 +48,9 @@ sub install_dev {
     assert_script_run('qvm-run -p sd-dev "git clone https://github.com/freedomofpress/securedrop-workstation"');
     assert_script_run('qvm-run -p sd-dev "git -C securedrop-workstation checkout ' . get_var('GIT_REF') . '"');
 
+    # Set up config.json (mainly for "dev" to be correct enviornment)
+    assert_script_run('qvm-run -p sd-dev "echo {\"submission_key_fpr\": \"65A1B5FF195B56353CC63DFFCC40EF1228271441\", \"hidserv\": {\"hostname\": \"bnbo6ryxq24fz27chs5fidscyqhw2hlyweelg4nmvq76tpxvofpyn4qd.onion\", \"key\": \"FDF476DUDSB5M27BIGEVIFCFGHQJ46XS3STAP7VG6Z2OWXLHWZPA\"}, \"environment\": \"dev\", \"vmsizes\": {\"sd_app\": 10, \"sd_log\": 5}} | tee securedrop-workstation/config.json"');
+
     # SecureDrop dev. env. according to https://developers.securedrop.org/en/latest/setup_development.html
     # DOCKER INSTALL according to https://docs.docker.com/engine/install/debian/
     assert_script_run('qvm-run -p sd-dev "sudo apt-get update"');
@@ -69,12 +72,6 @@ sub install_dev {
     assert_script_run('qvm-run -p sd-dev "cd securedrop-workstation && make build-rpm"', timeout => 1000);
     assert_script_run("qvm-run --pass-io sd-dev 'cat /home/user/securedrop-workstation/rpm-build/RPMS/noarch/*.rpm' > /tmp/sdw.rpm");
     assert_script_run('sudo dnf -y install /tmp/sdw.rpm', timeout => 1000);
-
-    # setup dev config.json
-    assert_script_run('echo {\"submission_key_fpr\": \"65A1B5FF195B56353CC63DFFCC40EF1228271441\", \"hidserv\": {\"hostname\": \"bnbo6ryxq24fz27chs5fidscyqhw2hlyweelg4nmvq76tpxvofpyn4qd.onion\", \"key\": \"FDF476DUDSB5M27BIGEVIFCFGHQJ46XS3STAP7VG6Z2OWXLHWZPA\"}, \"environment\": \"dev\", \"vmsizes\": {\"sd_app\": 10, \"sd_log\": 5}} | sudo tee /usr/share/securedrop-workstation-dom0-config/config.json');
-    assert_script_run('curl https://raw.githubusercontent.com/freedomofpress/securedrop/d91dc67/securedrop/tests/files/test_journalist_key.sec.no_passphrase | sudo tee /usr/share/securedrop-workstation-dom0-config/sd-journalist.sec');
-    assert_script_run('sdw-admin --validate');
-
 };
 
 sub run {

--- a/tests/securedrop/test_dom0.pm
+++ b/tests/securedrop/test_dom0.pm
@@ -35,8 +35,16 @@ sub run {
     # See https://github.com/freedomofpress/securedrop-workstation/issues/1411
     assert_script_run('rpm -q xorg-x11-server-Xvfb || sudo qubes-dom0-update -y xorg-x11-server-Xvfb', timeout => 300);
 
+    # FIXME: DEBUG
+    assert_script_run('qvm-run -p sd-dev "cd securedrop-workstation && git checkout main && git pull"');
+    assert_script_run("rm securedrop-workstation && qvm-run --pass-io sd-dev 'tar -c -C /home/user/ securedrop-workstation' | tar xvf -", timeout=>300);
+    assert_script_run('qvm-run -p whonix-gateway-17 "ls /etc/apt/sources.list.d/"');
+    assert_script_run('qvm-run -p sd-base-bookworm-template "ls /etc/apt/sources.list.d/"');
+    assert_script_run('qvm-run -p sd-large-bookworm-template "ls /etc/apt/sources.list.d/"');
+
     # Set up credentials
-    script_run('ln -s /usr/share/securedrop-workstation-dom0-config/config.json /home/user/securedrop-workstation/config.json');
+    assert_script_run('echo "{\"submission_key_fpr\": \"65A1B5FF195B56353CC63DFFCC40EF1228271441\", \"hidserv\": {\"hostname\": \"bnbo6ryxq24fz27chs5fidscyqhw2hlyweelg4nmvq76tpxvofpyn4qd.onion\", \"key\": \"FDF476DUDSB5M27BIGEVIFCFGHQJ46XS3STAP7VG6Z2OWXLHWZPA\"}, \"environment\": \"dev\", \"vmsizes\": {\"sd_app\": 10, \"sd_log\": 5}}" | sudo tee /usr/share/securedrop-workstation-dom0-config/config.json');
+    assert_script_run('cp /usr/share/securedrop-workstation-dom0-config/config.json /home/user/securedrop-workstation/config.json');
     script_run('ln -s /usr/share/securedrop-workstation-dom0-config/sd-journalist.sec /home/user/securedrop-workstation/sd-journalist.sec');
 
     # Run tests (xvfb-run needed to simulate screen in root console)


### PR DESCRIPTION
Config.json, which sets among other things the packages "environment" (prod, staging, dev) was set to prod in all cases. This makes it adequate for each environment.

As usual, someone from the SecureDrop team will take a look and once we're ready we'll mark this as ready for review.