### PR TITLE
Remove whonix_firstrun.pm's 'sys-whonix' name param

### DIFF
--- a/tests/whonix_firstrun.pm
+++ b/tests/whonix_firstrun.pm
@@ -18,29 +18,20 @@
 use base "installedtest";
 use strict;
 use testapi;
-use OpenQA::Test::RunArgs;
 
 sub run {
-    my ($self, $args) = @_;
+    my ($self) = @_;
 
     if (check_var('SKIP_INSTALL', '1')) {
         return;
     }
 
-    my $whonix_gateway = "sys-whonix";
-    if (exists $args->{whonix_gw_override}) {
-        $whonix_gateway = $args->{whonix_gw_override};
-    } else {
-    }
-
     $self->select_gui_console;
 
-    my $start_whonix_gw_cmd = sprintf "qvm-start %s", $whonix_gateway;
-    x11_start_program($start_whonix_gw_cmd, valid => 0);
+    x11_start_program('qvm-start sys-whonix', valid => 0);
     if (!check_screen(['whonix-connected', 'whonix-firstrun', 'whonix-news'], 120)) {
         # no firstrun wizard? maybe already accepted - verify it
-        my $run_whonixcheck_cmd = sprintf "qvm-run %s 'whonixcheck --gui'", $whonix_gateway;
-        x11_start_program($run_whonixcheck_cmd, valid => 0);
+        x11_start_program('qvm-run sys-whonix \'whonixcheck --gui\'', valid => 0);
         assert_screen('whonix-connected', timeout => 60);
     }
 


### PR DESCRIPTION
In commit ef7fbce SecureDrop introduced the parameterization of 'sys-whonix' because it included a custom 'sd-whonix' which also needed to have it's firstboot prompts dismissed. Now that the SecureDrop Workstation no longer has 'sd-whonix', there is no case for needing this parameterization.

This essentially reverts the whonix-relevant portion of the [above-referenced commit](https://github.com/QubesOS/openqa-tests-qubesos/commit/ef7fbcecb2a76ce57d1b03e782988c53efae15f7#diff-28b3e18f2f6d4fcf9026f33adfa89d43b8ee8e577226ca2eb73ddc1eea34e459).