### PR TITLE
Enable verbose debugging on legacy-dist's fixes script

### DIFF
--- a/extra-files/qubesteststub/__init__.py
+++ b/extra-files/qubesteststub/__init__.py
@@ -77,6 +77,9 @@ class DefaultPV(qubes.ext.Extension):
                 vm.features['pci-e820-host'] = False
                 vm.kernelopts += " iommu=soft"
 
+        if "whonix" in vm.name:
+            vm.features['service.debug-kicksecure'] = True
+
     @qubes.ext.handler('domain-start')
     async def on_domain_start(self, vm, event, **kwargs):
         has_pci_devices = (len(list(vm.devices['pci'].get_assigned_devices()))

--- a/extra-files/update/zsystemtests.py
+++ b/extra-files/update/zsystemtests.py
@@ -111,10 +111,3 @@ def zsystemtests(os_data, log, **kwargs):
 
     subprocess.call(["systemctl", "disable", "dnsmasq"],
                     stdin=subprocess.DEVNULL)
-
-    if (
-        os.path.exists("/usr/share/anon-gw-base-files/gateway")
-        or os.path.exists("/usr/share/anon-ws-base-files/workstation")
-    ):
-        subprocess.call(["systemctl", "enable", "check-user-slice-on-shutdown.service"],
-                        stdin=subprocess.DEVNULL)


### PR DESCRIPTION
Hopefully will help us figure out what went wrong [here](https://openqa.qubes-os.org/tests/173881#step/whonix_firstrun/8).

(I may follow this up with another PR to enable something that will detect if legacy-dist.service got stuck and complain, so that we can tell when we've hit a situation where the logs generated by this are interesting.)

EDIT: PR has been changed to enable a qvm-service instead. Some Whonix-side code changes will be made to look for this new service.