### PR TITLE
Install packagekit in Debian and Fedora

### DIFF
--- a/extra-files/system-tests/vm.sls
+++ b/extra-files/system-tests/vm.sls
@@ -37,10 +37,12 @@ vm-packages:
 {% endif %}
 {% if grains['os'] == 'Fedora' and grains['osmajorrelease'] >= 29 %}
       - createrepo_c
+      - PackageKit
 {% elif grains['os'] == 'CentOS' and grains['osmajorrelease'] >= 8 %}
       - createrepo_c
 {% elif grains['os'] == 'Debian' and grains['osmajorrelease'] >= 11 %}
       - createrepo-c
+      - packagekit
 {% elif grains['os'] == 'Arch' %}
       - createrepo_c
 {% elif grains['os'] != 'Gentoo' %}


### PR DESCRIPTION
Packagekit needs to be previously installed in templates to test if it works with proxy:
https://github.com/QubesOS/qubes-core-admin/pull/856